### PR TITLE
Update 110-cinder.sh

### DIFF
--- a/tools/deployment/multinode/110-cinder.sh
+++ b/tools/deployment/multinode/110-cinder.sh
@@ -26,7 +26,13 @@ pod:
 conf:
   cinder:
     DEFAULT:
-      backup_driver: cinder.backup.drivers.swift
+      backup_driver: cinder.backup.drivers.ceph
+  ceph:
+    pools:
+      backup:
+        crush_rule: replicated_rule
+      volume:
+        crush_rule: replicated_rule
 EOF
 helm upgrade --install cinder ./cinder \
   --namespace=openstack \


### PR DESCRIPTION
1 make ceph the default cinder backup backend in the deployment script
2 make ceph crush rule name configurable in the deployment script